### PR TITLE
Add deletion flag for TLAS build

### DIFF
--- a/src/rendering/buffer/to_free_list.cpp
+++ b/src/rendering/buffer/to_free_list.cpp
@@ -36,7 +36,7 @@ void ToFreeList::pushInstance(Instance* instance)
     }
 
     instances.push_back(instance);
-    instance->scheduledForDeletion = true;
+    instance->isScheduledForDeletion = true;
     instance->scene->isTlasDirty = true;
 }
 

--- a/src/rendering/scene.cpp
+++ b/src/rendering/scene.cpp
@@ -11,7 +11,7 @@
 using namespace DirectX;
 
 Instance::Instance(Scene* scene, uint32_t id)
-    : scene(scene), id(id), scheduledForDeletion(false)
+    : scene(scene), id(id)
 {}
 
 void Instance::markReadyForBlasBuild()
@@ -114,7 +114,7 @@ void Scene::makeTlas(ID3D12GraphicsCommandList4* cmdList, ToFreeList& toFreeList
     uint32_t instanceDescIdx = 0;
     for (const auto& [instanceId, instance] : this->instances)
     {
-        if (instance->scheduledForDeletion)
+        if (instance->isScheduledForDeletion)
         {
             continue;
         }
@@ -124,8 +124,7 @@ void Scene::makeTlas(ID3D12GraphicsCommandList4* cmdList, ToFreeList& toFreeList
         memcpy(instanceDesc.Transform, &instance->transform, sizeof(XMFLOAT3X4));
         instanceDesc.InstanceID = instanceId;
         instanceDesc.InstanceMask = 1;
-        instanceDesc.AccelerationStructure =
-            instance->geoWrapper.dev_blas->GetGPUVirtualAddress();
+        instanceDesc.AccelerationStructure = instance->geoWrapper.dev_blas->GetGPUVirtualAddress();
     }
 
     AcsHelper::TlasBuildInputs inputs;

--- a/src/rendering/scene.h
+++ b/src/rendering/scene.h
@@ -25,7 +25,7 @@ private:
 
     AcsHelper::GeometryWrapper geoWrapper;
 
-    bool scheduledForDeletion{ false };
+    bool isScheduledForDeletion{ false };
 
     Instance(Scene* scene, uint32_t id);
 


### PR DESCRIPTION
## Summary
- track whether an `Instance` is scheduled for deletion
- mark TLAS dirty when scheduling an instance for deletion
- omit scheduled instances when building the TLAS

## Testing
- `cmake --preset debug` *(fails: Could not find DXC_EXECUTABLE)*

------
https://chatgpt.com/codex/tasks/task_e_684f674b9b108325b12a7d870193e7db