### PR TITLE
Implement GLTF loading

### DIFF
--- a/src/rendering/scene/gltf_loader.cpp
+++ b/src/rendering/scene/gltf_loader.cpp
@@ -2,6 +2,9 @@
 
 #include "tinygltf/tiny_gltf.h"
 
+#include "rendering/buffer/to_free_list.h"
+#include <algorithm>
+#include <cctype>
 #include "scene.h"
 
 using namespace tinygltf;
@@ -12,6 +15,260 @@ namespace GltfLoader
 void loadGltf(const std::string& filePath, ::Scene& scene)
 {
     printf("Loading GLTF file: %s\n", filePath.c_str());
+
+    tinygltf::Model model;
+    tinygltf::TinyGLTF loader;
+    std::string err;
+    std::string warn;
+
+    std::string extension = filePath.substr(filePath.find_last_of('.') + 1);
+    std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    const bool loaded = (extension == "glb")
+                            ? loader.LoadBinaryFromFile(&model, &err, &warn, filePath)
+                            : loader.LoadASCIIFromFile(&model, &err, &warn, filePath);
+
+    if (!warn.empty())
+    {
+        printf("glTF warning: %s\n", warn.c_str());
+    }
+    if (!err.empty())
+    {
+        printf("glTF error: %s\n", err.c_str());
+    }
+    if (!loaded)
+    {
+        printf("Failed to load glTF file\n");
+        return;
+    }
+
+    ToFreeList toFreeList;
+
+    std::vector<uint32_t> materialIds;
+    materialIds.reserve(model.materials.size());
+    for (const Material& gltfMat : model.materials)
+    {
+        ::Material material;
+        if (gltfMat.pbrMetallicRoughness.baseColorFactor.size() >= 3)
+        {
+            const double* color = gltfMat.pbrMetallicRoughness.baseColorFactor.data();
+            material.diffuseColor = {
+                static_cast<float>(color[0]),
+                static_cast<float>(color[1]),
+                static_cast<float>(color[2]),
+            };
+            const bool anyDiffuse = material.diffuseColor.x != 0 || material.diffuseColor.y != 0
+                                   || material.diffuseColor.z != 0;
+            material.diffuseWeight = anyDiffuse ? 1.f : 0.f;
+        }
+        else
+        {
+            material.diffuseWeight = 0.f;
+        }
+
+        if (gltfMat.emissiveFactor.size() == 3)
+        {
+            material.emissiveColor = {
+                static_cast<float>(gltfMat.emissiveFactor[0]),
+                static_cast<float>(gltfMat.emissiveFactor[1]),
+                static_cast<float>(gltfMat.emissiveFactor[2]),
+            };
+            const bool anyEmissive = material.emissiveColor.x != 0 || material.emissiveColor.y != 0
+                                     || material.emissiveColor.z != 0;
+            material.emissiveStrength = anyEmissive ? 1.f : 0.f;
+        }
+
+        const uint32_t id = scene.addMaterial(toFreeList, &material);
+        materialIds.push_back(id);
+    }
+
+    const auto readAccessorData = [&](const tinygltf::Accessor& accessor) {
+        const tinygltf::BufferView& view = model.bufferViews[accessor.bufferView];
+        const tinygltf::Buffer& buffer = model.buffers[view.buffer];
+        return buffer.data.data() + view.byteOffset + accessor.byteOffset;
+    };
+
+    const auto getStride = [&](const tinygltf::Accessor& accessor) {
+        const tinygltf::BufferView& view = model.bufferViews[accessor.bufferView];
+        if (view.byteStride != 0)
+        {
+            return static_cast<size_t>(view.byteStride);
+        }
+
+        size_t componentSize = 0;
+        switch (accessor.componentType)
+        {
+        case TINYGLTF_COMPONENT_TYPE_FLOAT:
+            componentSize = 4;
+            break;
+        case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+            componentSize = 2;
+            break;
+        case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+            componentSize = 4;
+            break;
+        default:
+            componentSize = 4;
+            break;
+        }
+
+        int numComponents = 1;
+        switch (accessor.type)
+        {
+        case TINYGLTF_TYPE_VEC2:
+            numComponents = 2;
+            break;
+        case TINYGLTF_TYPE_VEC3:
+            numComponents = 3;
+            break;
+        case TINYGLTF_TYPE_VEC4:
+            numComponents = 4;
+            break;
+        default:
+            break;
+        }
+
+        return componentSize * static_cast<size_t>(numComponents);
+    };
+
+    for (const Node& node : model.nodes)
+    {
+        if (node.mesh < 0)
+        {
+            continue;
+        }
+
+        DirectX::XMMATRIX transform = DirectX::XMMatrixIdentity();
+        if (node.matrix.size() == 16)
+        {
+            transform = DirectX::XMMATRIX(static_cast<float>(node.matrix[0]),
+                                           static_cast<float>(node.matrix[1]),
+                                           static_cast<float>(node.matrix[2]),
+                                           static_cast<float>(node.matrix[3]),
+                                           static_cast<float>(node.matrix[4]),
+                                           static_cast<float>(node.matrix[5]),
+                                           static_cast<float>(node.matrix[6]),
+                                           static_cast<float>(node.matrix[7]),
+                                           static_cast<float>(node.matrix[8]),
+                                           static_cast<float>(node.matrix[9]),
+                                           static_cast<float>(node.matrix[10]),
+                                           static_cast<float>(node.matrix[11]),
+                                           static_cast<float>(node.matrix[12]),
+                                           static_cast<float>(node.matrix[13]),
+                                           static_cast<float>(node.matrix[14]),
+                                           static_cast<float>(node.matrix[15]));
+        }
+        else
+        {
+            if (node.translation.size() == 3)
+            {
+                transform *= DirectX::XMMatrixTranslation(static_cast<float>(node.translation[0]),
+                                                          static_cast<float>(node.translation[1]),
+                                                          static_cast<float>(node.translation[2]));
+            }
+
+            if (node.rotation.size() == 4)
+            {
+                const DirectX::XMVECTOR quat = DirectX::XMVectorSet(static_cast<float>(node.rotation[0]),
+                                                                    static_cast<float>(node.rotation[1]),
+                                                                    static_cast<float>(node.rotation[2]),
+                                                                    static_cast<float>(node.rotation[3]));
+                transform *= DirectX::XMMatrixRotationQuaternion(quat);
+            }
+
+            if (node.scale.size() == 3)
+            {
+                transform *= DirectX::XMMatrixScaling(static_cast<float>(node.scale[0]),
+                                                     static_cast<float>(node.scale[1]),
+                                                     static_cast<float>(node.scale[2]));
+            }
+        }
+
+        const Mesh& mesh = model.meshes[node.mesh];
+        for (const Primitive& prim : mesh.primitives)
+        {
+            Instance* instance = scene.requestNewInstance(toFreeList);
+
+            uint32_t matId = MATERIAL_ID_INVALID;
+            if (prim.material >= 0 && static_cast<size_t>(prim.material) < materialIds.size())
+            {
+                matId = materialIds[prim.material];
+            }
+            instance->setMaterialId(matId);
+
+            const Accessor& posAccessor = model.accessors[prim.attributes.find("POSITION")->second];
+            const Accessor& norAccessor = model.accessors[prim.attributes.find("NORMAL")->second];
+            const Accessor* uvAccessor = nullptr;
+            const auto uvIt = prim.attributes.find("TEXCOORD_0");
+            if (uvIt != prim.attributes.end())
+            {
+                uvAccessor = &model.accessors[uvIt->second];
+            }
+
+            const size_t vertCount = posAccessor.count;
+            instance->host_verts.resize(vertCount);
+
+            const unsigned char* posData = readAccessorData(posAccessor);
+            const unsigned char* norData = readAccessorData(norAccessor);
+            const unsigned char* uvData = uvAccessor ? readAccessorData(*uvAccessor) : nullptr;
+
+            const size_t posStride = getStride(posAccessor);
+            const size_t norStride = getStride(norAccessor);
+            const size_t uvStride = uvAccessor ? getStride(*uvAccessor) : 0;
+
+            for (size_t v = 0; v < vertCount; ++v)
+            {
+                const float* p = reinterpret_cast<const float*>(posData + posStride * v);
+                const float* n = reinterpret_cast<const float*>(norData + norStride * v);
+
+                DirectX::XMFLOAT2 uv = { 0.f, 0.f };
+                if (uvAccessor)
+                {
+                    const float* uvf = reinterpret_cast<const float*>(uvData + uvStride * v);
+                    uv = { uvf[0], uvf[1] };
+                }
+
+                instance->host_verts[v] = { { p[0], p[1], p[2] }, { n[0], n[1], n[2] }, uv };
+            }
+
+            if (prim.indices >= 0)
+            {
+                const Accessor& idxAccessor = model.accessors[prim.indices];
+                const unsigned char* idxData = readAccessorData(idxAccessor);
+                const size_t idxCount = idxAccessor.count;
+                instance->host_idxs.resize(idxCount);
+
+                const size_t idxStride = getStride(idxAccessor);
+
+                for (size_t i = 0; i < idxCount; ++i)
+                {
+                    uint32_t idx = 0;
+                    switch (idxAccessor.componentType)
+                    {
+                    case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+                        idx = *(reinterpret_cast<const uint8_t*>(idxData + idxStride * i));
+                        break;
+                    case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+                        idx = *(reinterpret_cast<const uint16_t*>(idxData + idxStride * i));
+                        break;
+                    case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+                        idx = *(reinterpret_cast<const uint32_t*>(idxData + idxStride * i));
+                        break;
+                    default:
+                        break;
+                    }
+                    instance->host_idxs[i] = idx;
+                }
+            }
+
+            DirectX::XMStoreFloat3x4(&instance->transform, transform);
+
+            scene.markInstanceReadyForBlasBuild(instance);
+        }
+    }
+
+    toFreeList.freeAll();
 }
 
-} // namespace GLtfLoader
+} // namespace GltfLoader


### PR DESCRIPTION
## Summary
- implement `GltfLoader::loadGltf()`
- parse materials (diffuse and emissive)
- construct scene instances from meshes and primitives
- handle `.glb` extension case-insensitively
- zero diffuse weight when diffuse component is missing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868c7abb9e8832586432d10550f1651