### PR TITLE
Add shader caching support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,26 @@ target_link_directories(Biomeinator PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/external/lib"
 )
 
-target_compile_definitions(Biomeinator PRIVATE CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+file(GLOB_RECURSE SHADER_SOURCE_FILES CONFIGURE_DEPENDS "${SRC_DIR}/shaders/*.slang")
+
+set(SHADER_CACHE_DIR "${CMAKE_BINARY_DIR}/shaders")
+set(SHADER_CACHE_BLOB "${SHADER_CACHE_DIR}/linked_program.slangblob")
+set(SHADER_CACHE_STAMP "${SHADER_CACHE_DIR}/cache.stamp")
+
+file(MAKE_DIRECTORY "${SHADER_CACHE_DIR}")
+
+add_custom_command(
+    OUTPUT ${SHADER_CACHE_STAMP}
+    COMMAND ${CMAKE_COMMAND} -E rm -f ${SHADER_CACHE_BLOB}
+    COMMAND ${CMAKE_COMMAND} -E touch ${SHADER_CACHE_STAMP}
+    DEPENDS ${SHADER_SOURCE_FILES}
+)
+add_custom_target(shader_cache DEPENDS ${SHADER_CACHE_STAMP})
+add_dependencies(Biomeinator shader_cache)
+
+target_compile_definitions(Biomeinator PRIVATE
+    CMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+    CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}")
 target_link_libraries(Biomeinator PRIVATE user32 d3d12 dxgi slang)
 
 file(GLOB RUNTIME_DLLS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/external/bin/*.dll")


### PR DESCRIPTION
## Summary
- add a shader caching system in CMake
- load cached linked_program.slangblob if present
- serialize shaders to the cache directory when compiled
- expose `CMAKE_BINARY_DIR` to the code

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885781e510083259bc222f318211a13