### PR TITLE
Implement multiple importance sampling

### DIFF
--- a/src/shaders/light_sampling.slang
+++ b/src/shaders/light_sampling.slang
@@ -94,6 +94,22 @@ DirectLightingSample sampleDirectLighting(float3 origin_WS, float3 normal_WS, fl
     return result;
 }
 
+float calculateLightPdf(const HitInfo hitInfo, const float3 wi_WS)
+{
+    for (uint i = 0; i < sceneParams.numAreaLights; ++i)
+    {
+        const AreaLight light = areaLights[i];
+        if (light.instanceId == hitInfo.instanceId && light.triangleIdx == hitInfo.triangleIdx)
+        {
+            const float lightPickPdf = 1.f / sceneParams.numAreaLights;
+            const float r2 = hitInfo.hitT * hitInfo.hitT;
+            const float cosTheta = absCosTheta(-wi_WS, light.normal_WS);
+            return lightPickPdf * light.rcpArea * r2 / cosTheta;
+        }
+    }
+    return 0.f;
+}
+
 [shader("closesthit")]
 void ClosestHit_Lights(inout Payload payload, BuiltInTriangleIntersectionAttributes attribs)
 {

--- a/src/shaders/main.slang
+++ b/src/shaders/main.slang
@@ -37,6 +37,8 @@ void RayGeneration()
         payload.pathColor = float3(0, 0, 0);
         payload.flags = 0;
         payload.rng = initRandomSampler4(uint4(pixelIdx, sampleIdx, sceneParams.frameNumber));
+        payload.lastBsdfPdf = 0.f;
+        payload.lastSampleWasSpecular = 1;
 
         const float2 jitter = float2(payload.rng.nextFloat(), payload.rng.nextFloat());
         const float3 targetPos_WS = calculateRayTarget(pixelIdx + jitter, size);
@@ -47,8 +49,8 @@ void RayGeneration()
         ray.TMin = 0.001;
         ray.TMax = 1000;
 
-        bool pathHadContribution = pathTraceRay(ray, payload);
-        if (pathHadContribution)
+        pathTraceRay(ray, payload);
+        if (luminance(payload.pathColor) > 0.f)
         {
             accumulatedColor += payload.pathColor;
         }

--- a/src/shaders/materials.slang
+++ b/src/shaders/materials.slang
@@ -138,7 +138,7 @@ BsdfSample sampleBsdf(
     {
         const float3 wi_WS = normalize(reflect(-wo_WS, normal_WS));
         result.wi_WS = wi_WS;
-        result.pdf = fresnelReflectance;
+        result.pdf = 0.f;
         result.bsdfValue = material.specularColor * fresnelReflectance;
         result.wasSpecular = true;
     }
@@ -152,4 +152,51 @@ BsdfSample sampleBsdf(
     }
 
     return result;
+}
+
+float bsdfPdf(
+    const Material material,
+    const float2 uv,
+    const float3 wo_WS,
+    const float3 wi_WS,
+    const float3 normal_WS)
+{
+    if (material.hasDiffuse == 0 && material.hasSpecularReflection == 0)
+    {
+        return 0.f;
+    }
+
+    const bool hasReflect = (material.hasSpecularReflection == 1);
+    const bool hasTransmit = (material.hasDiffuse == 1);
+
+    float fresnelReflectance = 0.f;
+    if (hasReflect && !hasTransmit)
+    {
+        fresnelReflectance = 1.f;
+    }
+    else if (!hasReflect && hasTransmit)
+    {
+        fresnelReflectance = 0.f;
+    }
+    else if (hasReflect && hasTransmit)
+    {
+        fresnelReflectance = walterFresnel(material.ior, cosTheta(wo_WS, normal_WS));
+    }
+
+    if (hasReflect)
+    {
+        const float3 reflDir_WS = normalize(reflect(-wo_WS, normal_WS));
+        const float cosRefl = dot(reflDir_WS, wi_WS);
+        if (cosRefl > 1.f - 1e-4f)
+        {
+            return 0.f;
+        }
+    }
+
+    if (hasTransmit)
+    {
+        return absCosTheta(wi_WS, normal_WS) * (1.f - fresnelReflectance) / M_PI;
+    }
+
+    return 0.f;
 }

--- a/src/shaders/path_tracing.slang
+++ b/src/shaders/path_tracing.slang
@@ -62,13 +62,30 @@ void calcPathPosAndNormal(const RayDesc ray, const Payload payload, out float3 h
     normal_WS = faceforward(payload.hitInfo.normal_WS, -ray.Direction);
 }
 
+float powerHeuristic(const float pdfA, const float pdfB)
+{
+    const float pdfA2 = pdfA * pdfA;
+    const float pdfB2 = pdfB * pdfB;
+    return pdfA2 / (pdfA2 + pdfB2);
+}
+
 void bounceRay(inout RayDesc ray, inout Payload payload, bool isLastBounce)
 {
     const Material material = materials[payload.materialId];
 
+    float3 hitPos_WS, normal_WS;
+    calcPathPosAndNormal(ray, payload, hitPos_WS, normal_WS);
+    const float3 wo_WS = -ray.Direction;
+
     if (material.emissiveStrength > 0)
     {
-        payload.pathColor += payload.pathWeight * material.emissiveColor * material.emissiveStrength;
+        float emissionWeight = 1.f;
+        if (!payload.lastSampleWasSpecular)
+        {
+            const float lightPdf = calculateLightPdf(payload.hitInfo, ray.Direction);
+            emissionWeight = powerHeuristic(payload.lastBsdfPdf, lightPdf);
+        }
+        payload.pathColor += payload.pathWeight * material.emissiveColor * material.emissiveStrength * emissionWeight;
     }
 
     // material has no reflectance
@@ -78,22 +95,28 @@ void bounceRay(inout RayDesc ray, inout Payload payload, bool isLastBounce)
         return;
     }
 
+    const DirectLightingSample lightSample = sampleDirectLighting(hitPos_WS, normal_WS, payload.rng.nextFloat3());
+    if (lightSample.didHitLight)
+    {
+        const float3 bsdfValue = evaluateBsdf<true>(material, payload.hitInfo.uv, wo_WS, lightSample.wi_WS, normal_WS);
+        const float bsdfPdfVal = bsdfPdf(material, payload.hitInfo.uv, wo_WS, lightSample.wi_WS, normal_WS);
+        const float misWeight = powerHeuristic(lightSample.pdf, bsdfPdfVal);
+        payload.pathColor += payload.pathWeight * bsdfValue * absCosTheta(lightSample.wi_WS, normal_WS) * lightSample.Le * misWeight / lightSample.pdf;
+    }
+
     if (isLastBounce)
     {
+        payload.flags |= PAYLOAD_FLAG_PATH_FINISHED;
         return;
     }
 
-    float3 hitPos_WS, normal_WS;
-    calcPathPosAndNormal(ray, payload, hitPos_WS, normal_WS);
-    float3 wo_WS = -ray.Direction;
+    const BsdfSample sample = sampleBsdf(material, payload.hitInfo.uv, wo_WS, normal_WS, payload.rng);
+    payload.lastBsdfPdf = sample.pdf;
+    payload.lastSampleWasSpecular = sample.wasSpecular ? 1u : 0u;
 
-    BsdfSample sample = sampleBsdf(material, payload.hitInfo.uv, wo_WS, normal_WS, payload.rng);
-
-    float3 adjustedBsdfValue = sample.bsdfValue / sample.pdf;
-    if (!sample.wasSpecular)
-    {
-        adjustedBsdfValue *= absCosTheta(sample.wi_WS, normal_WS);
-    }
+    const float3 adjustedBsdfValue = sample.wasSpecular
+        ? sample.bsdfValue
+        : (sample.bsdfValue / sample.pdf) * absCosTheta(sample.wi_WS, normal_WS);
     payload.pathWeight *= adjustedBsdfValue;
 
     ray.Origin = hitPos_WS + 0.001f * normal_WS;
@@ -102,7 +125,7 @@ void bounceRay(inout RayDesc ray, inout Payload payload, bool isLastBounce)
     ray.TMax = 10000.f;
 }
 
-bool pathTraceRay(RayDesc ray, inout Payload payload)
+void pathTraceRay(RayDesc ray, inout Payload payload)
 {
     for (uint pathDepth = 0; pathDepth < MAX_PATH_DEPTH; ++pathDepth)
     {
@@ -112,7 +135,7 @@ bool pathTraceRay(RayDesc ray, inout Payload payload)
             const float survivalProbability = max(saturate(luminance(payload.pathWeight)), 0.1f);
             if (payload.rng.nextFloat() >= survivalProbability)
             {
-                return false;
+                return;
             }
             payload.pathWeight /= survivalProbability;
         }
@@ -121,12 +144,12 @@ bool pathTraceRay(RayDesc ray, inout Payload payload)
 
         if (bool(payload.flags & PAYLOAD_FLAG_PATH_FINISHED))
         {
-            return true;
+            return;
         }
 
         if (payload.materialId == MATERIAL_ID_INVALID)
         {
-            return false;
+            return;
         }
 
         const bool isLastBounce = pathDepth == MAX_PATH_DEPTH - 1;
@@ -134,24 +157,10 @@ bool pathTraceRay(RayDesc ray, inout Payload payload)
 
         if (bool(payload.flags & PAYLOAD_FLAG_PATH_FINISHED))
         {
-            return true;
+            return;
         }
     }
-
-    float3 hitPos_WS, normal_WS;
-    calcPathPosAndNormal(ray, payload, hitPos_WS, normal_WS);
-    const DirectLightingSample lightSample = sampleDirectLighting(hitPos_WS, normal_WS, payload.rng.nextFloat3());
-
-    if (!lightSample.didHitLight)
-    {
-        return false;
-    }
-
-    float3 bsdfValue = evaluateBsdf<true /*calculateFresnelReflectance*/>(materials[payload.materialId], payload.hitInfo.uv, -ray.Direction, lightSample.wi_WS, normal_WS);
-    payload.pathWeight *= bsdfValue * absCosTheta(lightSample.wi_WS, normal_WS) / lightSample.pdf;
-    payload.pathColor += payload.pathWeight * lightSample.Le;
-
-    return true;
+    return;
 }
 
 [shader("closesthit")]

--- a/src/shaders/payload.slang
+++ b/src/shaders/payload.slang
@@ -42,5 +42,8 @@ struct Payload
 
     HitInfo hitInfo;
 
+    float lastBsdfPdf;
+    uint lastSampleWasSpecular;
+
     RandomSampler rng;
 };


### PR DESCRIPTION
## Summary
- add pdf helpers for BSDF and light evaluation
- record BSDF sample data in the payload
- integrate MIS into path tracing and direct lighting
- handle specular events with zero pdf and per-ray contribution checks in the raygen shader

## Testing
- `ctest 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689028da8b908325b25569ead0607099