### PR TITLE
Add test-output screenshot option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,10 @@ int main(int argc, char** argv)
     WindowManager::init();
     Renderer::init();
 
-    const bool hasTestOutput = SettingsManager::hasOption("test-output");
-    if (hasTestOutput)
+    if (SettingsManager::hasOption("test-output"))
     {
         const std::string path = SettingsManager::getAsString("test-output");
-        Renderer::queueScreenshot(path);
+        Renderer::queueScreenshot(true /*useTestOutputPath*/);
         Renderer::render();
         Renderer::flush();
         return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,16 @@ int main(int argc, char** argv)
     WindowManager::init();
     Renderer::init();
 
+    const bool hasTestOutput = SettingsManager::hasOption("test-output");
+    if (hasTestOutput)
+    {
+        const std::string path = SettingsManager::getAsString("test-output");
+        Renderer::queueScreenshot(path);
+        Renderer::render();
+        Renderer::flush();
+        return 0;
+    }
+
     for (MSG msg;;)
     {
         while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))

--- a/src/rendering/renderer.cpp
+++ b/src/rendering/renderer.cpp
@@ -759,13 +759,15 @@ struct ScreenshotRequest
     uint32_t height{ 0 };
     uint32_t rowPitchBytes{ 0 };
     uint32_t rowPitchBytesAligned{ 0 };
+    std::string path;
 };
 
 static ScreenshotRequest screenshotRequest;
 
-void queueScreenshot()
+void queueScreenshot(const std::string& filePath)
 {
     screenshotRequest.active = true;
+    screenshotRequest.path = filePath;
 }
 
 void captureQueuedScreenshot()
@@ -833,22 +835,32 @@ void finalizeQueuedScreenshot()
     }
     screenshotRequest.readbackBuffer->Unmap(0, nullptr);
 
-    wchar_t docPath[MAX_PATH];
-    if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, SHGFP_TYPE_CURRENT, docPath)))
+    std::filesystem::path path;
+    if (screenshotRequest.path.empty())
     {
-        throw std::runtime_error("Failed to get screenshots directory");
+        wchar_t docPath[MAX_PATH];
+        if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, SHGFP_TYPE_CURRENT, docPath)))
+        {
+            throw std::runtime_error("Failed to get screenshots directory");
+        }
+
+        const std::filesystem::path dir = std::filesystem::path(docPath) / L"biomeinator" / "screenshots";
+        std::filesystem::create_directories(dir);
+
+        SYSTEMTIME st{};
+        GetLocalTime(&st);
+        char fileName[64];
+        sprintf_s(
+            fileName, "%04d.%02d.%02d_%02d-%02d-%02d.png", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+
+        path = dir / fileName;
+    }
+    else
+    {
+        path = screenshotRequest.path;
+        std::filesystem::create_directories(path.parent_path());
     }
 
-    const std::filesystem::path dir = std::filesystem::path(docPath) / L"biomeinator" / "screenshots";
-    std::filesystem::create_directories(dir);
-
-    SYSTEMTIME st{};
-    GetLocalTime(&st);
-    char fileName[64];
-    sprintf_s(
-        fileName, "%04d.%02d.%02d_%02d-%02d-%02d.png", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
-
-    const std::filesystem::path path = dir / fileName;
     stbi_write_png(path.string().c_str(),
                    screenshotRequest.width,
                    screenshotRequest.height,
@@ -860,6 +872,7 @@ void finalizeQueuedScreenshot()
 
     screenshotRequest.readbackBuffer.Reset();
     screenshotRequest.active = false;
+    screenshotRequest.path.clear();
 }
 
 void render()

--- a/src/rendering/renderer.cpp
+++ b/src/rendering/renderer.cpp
@@ -848,7 +848,7 @@ void finalizeQueuedScreenshot()
             throw std::runtime_error("Failed to get screenshots directory");
         }
 
-        const std::filesystem::path dir = std::filesystem::path(documentsPath) / L"biomeinator" / "screenshots";
+        const std::filesystem::path dir = std::filesystem::path(documentsPath) / "biomeinator" / "screenshots";
 
         SYSTEMTIME st{};
         GetLocalTime(&st);

--- a/src/rendering/renderer.cpp
+++ b/src/rendering/renderer.cpp
@@ -838,7 +838,7 @@ void finalizeQueuedScreenshot()
     std::filesystem::path path;
     if (screenshotRequest.useTestOutputPath)
     {
-        path = SettingsManager::getAsString("test-output");
+        path = std::filesystem::absolute(SettingsManager::getAsString("test-output"));
     }
     else
     {

--- a/src/rendering/renderer.cpp
+++ b/src/rendering/renderer.cpp
@@ -759,15 +759,15 @@ struct ScreenshotRequest
     uint32_t height{ 0 };
     uint32_t rowPitchBytes{ 0 };
     uint32_t rowPitchBytesAligned{ 0 };
-    std::string path;
+    bool useTestOutputPath{ false };
 };
 
-static ScreenshotRequest screenshotRequest;
+static ScreenshotRequest screenshotRequest{};
 
-void queueScreenshot(const std::string& filePath)
+void queueScreenshot(const bool useTestOutputPath)
 {
     screenshotRequest.active = true;
-    screenshotRequest.path = filePath;
+    screenshotRequest.useTestOutputPath = useTestOutputPath;
 }
 
 void captureQueuedScreenshot()
@@ -836,30 +836,36 @@ void finalizeQueuedScreenshot()
     screenshotRequest.readbackBuffer->Unmap(0, nullptr);
 
     std::filesystem::path path;
-    if (screenshotRequest.path.empty())
+    if (screenshotRequest.useTestOutputPath)
     {
-        wchar_t docPath[MAX_PATH];
-        if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, SHGFP_TYPE_CURRENT, docPath)))
+        path = SettingsManager::getAsString("test-output");
+    }
+    else
+    {
+        wchar_t documentsPath[MAX_PATH];
+        if (!SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_PERSONAL, nullptr, SHGFP_TYPE_CURRENT, documentsPath)))
         {
             throw std::runtime_error("Failed to get screenshots directory");
         }
 
-        const std::filesystem::path dir = std::filesystem::path(docPath) / L"biomeinator" / "screenshots";
-        std::filesystem::create_directories(dir);
+        const std::filesystem::path dir = std::filesystem::path(documentsPath) / L"biomeinator" / "screenshots";
 
         SYSTEMTIME st{};
         GetLocalTime(&st);
         char fileName[64];
-        sprintf_s(
-            fileName, "%04d.%02d.%02d_%02d-%02d-%02d.png", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+        sprintf_s(fileName,
+                  "%04d.%02d.%02d_%02d-%02d-%02d.png",
+                  st.wYear,
+                  st.wMonth,
+                  st.wDay,
+                  st.wHour,
+                  st.wMinute,
+                  st.wSecond);
 
         path = dir / fileName;
     }
-    else
-    {
-        path = screenshotRequest.path;
-        std::filesystem::create_directories(path.parent_path());
-    }
+
+    std::filesystem::create_directories(path.parent_path());
 
     stbi_write_png(path.string().c_str(),
                    screenshotRequest.width,
@@ -871,8 +877,7 @@ void finalizeQueuedScreenshot()
     printf("Saved screenshot to %s\n", path.string().c_str());
 
     screenshotRequest.readbackBuffer.Reset();
-    screenshotRequest.active = false;
-    screenshotRequest.path.clear();
+    screenshotRequest = ScreenshotRequest();
 }
 
 void render()

--- a/src/rendering/renderer.h
+++ b/src/rendering/renderer.h
@@ -35,7 +35,7 @@ void render();
 
 void flush();
 
-void queueScreenshot();
+void queueScreenshot(const std::string& filePath = "");
 
 extern ComPtr<ID3D12Device5> device;
 

--- a/src/rendering/renderer.h
+++ b/src/rendering/renderer.h
@@ -35,7 +35,7 @@ void render();
 
 void flush();
 
-void queueScreenshot(const std::string& filePath = "");
+void queueScreenshot(const bool useTestOutputPath = false);
 
 extern ComPtr<ID3D12Device5> device;
 

--- a/src/settings_manager.cpp
+++ b/src/settings_manager.cpp
@@ -29,6 +29,16 @@ void parseArgs(const int argc, const char* const* argv)
         std::cout << options.help() << std::endl;
         exit(0);
     }
+
+    if (hasOption("test-output"))
+    {
+        const std::string& testOutputPath = getAsString("test-output");
+        if (!testOutputPath.ends_with(".png"))
+        {
+            std::cerr << "--test-output must be a .png" << std::endl;
+            exit(-1);
+        }
+    }
 }
 
 bool hasOption(const std::string& name)

--- a/src/settings_manager.cpp
+++ b/src/settings_manager.cpp
@@ -31,6 +31,11 @@ void parseArgs(const int argc, const char* const* argv)
     }
 }
 
+bool hasOption(const std::string& name)
+{
+    return parseResult.count(name) > 0;
+}
+
 bool getAsBool(const std::string& name)
 {
     return parseResult[name].as<bool>();
@@ -49,11 +54,6 @@ uint32_t getAsUint(const std::string& name)
 std::string getAsString(const std::string& name)
 {
     return parseResult[name].as<std::string>();
-}
-
-bool hasOption(const std::string& name)
-{
-    return parseResult.count(name) > 0;
 }
 
 } // namespace SettingsManager

--- a/src/settings_manager.cpp
+++ b/src/settings_manager.cpp
@@ -20,7 +20,7 @@ void parseArgs(const int argc, const char* const* argv)
     optionAdder("spp", "Samples per pixel", cxxopts::value<uint32_t>()->default_value("16"));
     optionAdder("maxPathDepth", "Maximum path depth", cxxopts::value<uint32_t>()->default_value("12"));
     optionAdder("scene", "Scene file (*.gltf; *.glb)", cxxopts::value<std::string>());
-    optionAdder("test-output", "Render one frame and save screenshot", cxxopts::value<std::string>());
+    optionAdder("test-output", "Test screenshot output path (*.png)", cxxopts::value<std::string>());
 
     parseResult = options.parse(argc, argv);
 

--- a/src/settings_manager.cpp
+++ b/src/settings_manager.cpp
@@ -20,6 +20,7 @@ void parseArgs(const int argc, const char* const* argv)
     optionAdder("spp", "Samples per pixel", cxxopts::value<uint32_t>()->default_value("16"));
     optionAdder("maxPathDepth", "Maximum path depth", cxxopts::value<uint32_t>()->default_value("12"));
     optionAdder("scene", "Scene file (*.gltf; *.glb)", cxxopts::value<std::string>());
+    optionAdder("test-output", "Render one frame and save screenshot", cxxopts::value<std::string>());
 
     parseResult = options.parse(argc, argv);
 
@@ -48,6 +49,11 @@ uint32_t getAsUint(const std::string& name)
 std::string getAsString(const std::string& name)
 {
     return parseResult[name].as<std::string>();
+}
+
+bool hasOption(const std::string& name)
+{
+    return parseResult.count(name) > 0;
 }
 
 } // namespace SettingsManager

--- a/src/settings_manager.cpp
+++ b/src/settings_manager.cpp
@@ -14,7 +14,7 @@ void parseArgs(const int argc, const char* const* argv)
 {
     Options options("Biomeinator.exe", "Real-time path traced voxel engine");
     OptionAdder optionAdder = options.add_options();
-    optionAdder("h,help", "Print usage");
+    optionAdder("h,help", "Print this message");
     optionAdder("width", "Window width", cxxopts::value<uint32_t>()->default_value("1920"));
     optionAdder("height", "Window height", cxxopts::value<uint32_t>()->default_value("1080"));
     optionAdder("spp", "Samples per pixel", cxxopts::value<uint32_t>()->default_value("16"));

--- a/src/settings_manager.h
+++ b/src/settings_manager.h
@@ -7,10 +7,11 @@ namespace SettingsManager
 
 void parseArgs(const int argc, const char* const* argv);
 
+bool hasOption(const std::string& name);
+
 bool getAsBool(const std::string& name);
 int getAsInt(const std::string& name);
 uint32_t getAsUint(const std::string& name);
 std::string getAsString(const std::string& name);
-bool hasOption(const std::string& name);
 
 } // namespace SettingsManager

--- a/src/settings_manager.h
+++ b/src/settings_manager.h
@@ -11,5 +11,6 @@ bool getAsBool(const std::string& name);
 int getAsInt(const std::string& name);
 uint32_t getAsUint(const std::string& name);
 std::string getAsString(const std::string& name);
+bool hasOption(const std::string& name);
 
 } // namespace SettingsManager


### PR DESCRIPTION
## Summary
- add `test-output` CLI option for saving a single-frame screenshot to a PNG file
- allow renderer to queue screenshots to an explicit path
- exit after rendering one frame when `test-output` is specified

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e79c06fc83259a6ccabbeddb8b85