### PR TITLE
Add JSON-driven regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.24)
 project(Biomeinator LANGUAGES CXX)
 
+include(FetchContent)
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -13,6 +15,8 @@ file(GLOB_RECURSE SRC_FILES
     "${SRC_DIR}/*.h"
     "${SRC_DIR}/*.slang"
 )
+
+list(FILTER SRC_FILES EXCLUDE REGEX "/tests/")
 
 # set up Visual Studio filters based on directory structure
 foreach(FILE IN LISTS SRC_FILES)
@@ -46,3 +50,22 @@ add_custom_command(TARGET Biomeinator POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${RUNTIME_DLLS}
     $<TARGET_FILE_DIR:Biomeinator>)
+
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.8.1
+)
+FetchContent_MakeAvailable(Catch2)
+
+set(TEST_SRC
+    "${SRC_DIR}/tests/main.cpp"
+    "${SRC_DIR}/tests/test_loader.cpp"
+)
+
+add_executable(BiomeinatorTests ${TEST_SRC})
+target_include_directories(BiomeinatorTests PRIVATE
+    ${SRC_DIR}
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/include"
+)
+target_link_libraries(BiomeinatorTests PRIVATE Catch2::Catch2WithMain Biomeinator)

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -1,0 +1,58 @@
+#include "test_loader.h"
+
+#include <catch2/catch_all.hpp>
+#include <filesystem>
+#include <stb/stb_image.h>
+#include <cmath>
+#include <cstdlib>
+
+TEST_CASE("Render regression tests")
+{
+    const auto tests = LoadTests(std::filesystem::path(CMAKE_SOURCE_DIR) / "tests/tests.json");
+    for (const TestCase &test : tests)
+    {
+        DYNAMIC_SECTION(test.name)
+        {
+            std::filesystem::create_directories(test.output.parent_path());
+            const std::filesystem::path goldenCopy = test.output.parent_path() / (test.name + "_GOLDEN.png");
+            std::filesystem::copy_file(test.golden, goldenCopy, std::filesystem::copy_options::overwrite_existing);
+
+            std::string command = std::string("./Biomeinator.exe --test-output ") + test.output.string();
+            for (const std::string &arg : test.args)
+            {
+                command += " " + arg;
+            }
+            const int ret = std::system(command.c_str());
+            REQUIRE(ret == 0);
+
+            int genW = 0;
+            int genH = 0;
+            int genC = 0;
+            unsigned char *generated = stbi_load(test.output.string().c_str(), &genW, &genH, &genC, 3);
+            REQUIRE(generated != nullptr);
+
+            int goldW = 0;
+            int goldH = 0;
+            int goldC = 0;
+            unsigned char *golden = stbi_load(goldenCopy.string().c_str(), &goldW, &goldH, &goldC, 3);
+            REQUIRE(golden != nullptr);
+
+            REQUIRE(genW == goldW);
+            REQUIRE(genH == goldH);
+
+            double sumSq = 0.0;
+            const size_t count = static_cast<size_t>(genW) * genH * 3;
+            for (size_t i = 0; i < count; ++i)
+            {
+                const double diff = static_cast<double>(generated[i]) - static_cast<double>(golden[i]);
+                sumSq += diff * diff;
+            }
+            stbi_image_free(generated);
+            stbi_image_free(golden);
+
+            const double rmse = std::sqrt(sumSq / count) / 255.0;
+            REQUIRE(rmse <= test.threshold);
+        }
+    }
+}
+

--- a/src/tests/test_loader.cpp
+++ b/src/tests/test_loader.cpp
@@ -1,0 +1,70 @@
+#include "test_loader.h"
+
+#include <fstream>
+#include <tinygltf/json.hpp>
+
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb/stb_image.h>
+
+std::vector<TestCase> LoadTests(const std::filesystem::path &jsonPath)
+{
+    std::ifstream file(jsonPath);
+    if (!file.is_open())
+    {
+        return {};
+    }
+
+    std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    if (content.empty())
+    {
+        return {};
+    }
+
+    if (content.front() != '{')
+    {
+        content.insert(content.begin(), '{');
+        content.push_back('}');
+    }
+
+    for (std::string::size_type pos = 0; (pos = content.find(",}")) != std::string::npos; )
+    {
+        content.erase(pos, 1);
+    }
+    for (std::string::size_type pos = 0; (pos = content.find(",]")) != std::string::npos; )
+    {
+        content.erase(pos, 1);
+    }
+
+    const nlohmann::json data = nlohmann::json::parse(content);
+    const std::filesystem::path testsDir = jsonPath.parent_path();
+
+    std::vector<TestCase> cases;
+    for (const nlohmann::json &t : data["tests"])
+    {
+        const std::string name = t.at("name").get<std::string>();
+
+        TestCase tc;
+        tc.name = name;
+        tc.golden = testsDir / t.at("golden").get<std::string>();
+        tc.output = std::filesystem::path("test_output") / (name + "_GENERATED.png");
+        tc.threshold = t.value("threshold", 0.0f);
+        tc.args = t.value("args", std::vector<std::string>{});
+
+        const std::filesystem::path scene = testsDir / t.at("scene").get<std::string>();
+        tc.args.push_back("--scene=" + scene.string());
+
+        int width = 0;
+        int height = 0;
+        int comp = 0;
+        if (stbi_info(tc.golden.string().c_str(), &width, &height, &comp) != 0)
+        {
+            tc.args.push_back("--width=" + std::to_string(width));
+            tc.args.push_back("--height=" + std::to_string(height));
+        }
+
+        cases.push_back(std::move(tc));
+    }
+
+    return cases;
+}
+

--- a/src/tests/test_loader.h
+++ b/src/tests/test_loader.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+struct TestCase
+{
+    std::string name;
+    std::vector<std::string> args;
+    std::filesystem::path output;
+    std::filesystem::path golden;
+    float threshold;
+};
+
+std::vector<TestCase> LoadTests(const std::filesystem::path &jsonPath);
+


### PR DESCRIPTION
## Summary
- Parse `tests.json` and create per-case arguments, auto-sizing images from golden files
- Run each test via Catch2, copying golden images and checking RMSE vs. threshold
- Add Catch2 and a `BiomeinatorTests` target to CMake

## Testing
- `g++ -std=c++20 -Iexternal/include -Isrc -c src/tests/test_loader.cpp -o /tmp/test_loader.o`
- `g++ -std=c++20 -Iexternal/include -Isrc -c src/tests/main.cpp -o /tmp/main.o` *(fails: catch2/catch_all.hpp: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68a27ca65bd4832590bdd3794fca4afe